### PR TITLE
Add support for custom user agent lists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ tasks.register('printVersion') {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifactId = 'iab-spiders-and-robots-client'
             from components.java
 
             pom {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 group = 'com.snowplowanalytics'
 archivesBaseName = 'iab-spiders-and-robots-client'
-version = '0.2.0'
+version = '0.2.1-M1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
@@ -121,22 +121,22 @@ public class IabClient {
     public IabResponse checkAt(String userAgent, InetAddress ipAddress, Date accurateAt) {
         assertCheckAtArguments(userAgent, ipAddress, accurateAt);
 
-        String userAgentLower = IabFile.toLowerCase(userAgent);
-
-        if (userAgentLower != null && matchesAny(userAgentLower, customIncludeUseragents)) {
-            return IabResponse.identifiedAsBrowser();
-        }
-
-        if (userAgentLower != null && matchesAny(userAgentLower, customExcludeUseragents)) {
-            return IabResponse.customExcludeCheckFailed();
-        }
-
         if (ipAddress != null && ipRanges.belong(ipAddress)) {
             return IabResponse.ipCheckFailed();
         }
 
         if (userAgent == null) {
             return IabResponse.identifiedAsBrowser();
+        }
+
+        String userAgentLower = IabFile.toLowerCase(userAgent);
+
+        if (matchesAny(userAgentLower, customIncludeUseragents)) {
+            return IabResponse.identifiedAsBrowser();
+        }
+
+        if (matchesAny(userAgentLower, customExcludeUseragents)) {
+            return IabResponse.customExcludeCheckFailed();
         }
 
         if (!includeUserAgents.present(userAgent, accurateAt)) {

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
@@ -47,9 +47,9 @@ public class IabClient {
 
     private ExcludeUserAgents excludeUserAgents;
 
-    private final List<String> customIncludeUseragents;
+    private final List<String> customIncludeUserAgents;
 
-    private final List<String> customExcludeUseragents;
+    private final List<String> customExcludeUserAgents;
 
     public IabClient(File ipFile,
                      File excludeUserAgentFile,
@@ -61,15 +61,15 @@ public class IabClient {
     public IabClient(File ipFile,
                      File excludeUserAgentFile,
                      File includeUserAgentFile,
-                     List<String> excludeUseragents,
-                     List<String> includeUseragents) throws IOException {
+                     List<String> excludeUserAgents,
+                     List<String> includeUserAgents) throws IOException {
         try (InputStream ip = FileUtils.openInputStream(ipFile);
              InputStream excludeUserAgent = FileUtils.openInputStream(excludeUserAgentFile);
              InputStream includeUserAgent = FileUtils.openInputStream(includeUserAgentFile)) {
             init(ip, excludeUserAgent, includeUserAgent);
         }
-        this.customExcludeUseragents = toLowerCaseList(excludeUseragents);
-        this.customIncludeUseragents = toLowerCaseList(includeUseragents);
+        this.customExcludeUserAgents = toLowerCaseList(excludeUserAgents);
+        this.customIncludeUserAgents = toLowerCaseList(includeUserAgents);
     }
 
     IabClient(InputStream ip,
@@ -82,11 +82,11 @@ public class IabClient {
     IabClient(InputStream ip,
               InputStream excludeUserAgent,
               InputStream includeUserAgent,
-              List<String> excludeUseragents,
-              List<String> includeUseragents) throws IOException {
+              List<String> excludeUserAgents,
+              List<String> includeUserAgents) throws IOException {
         init(ip, excludeUserAgent, includeUserAgent);
-        this.customExcludeUseragents = toLowerCaseList(excludeUseragents);
-        this.customIncludeUseragents = toLowerCaseList(includeUseragents);
+        this.customExcludeUserAgents = toLowerCaseList(excludeUserAgents);
+        this.customIncludeUserAgents = toLowerCaseList(includeUserAgents);
     }
 
     private void init(InputStream ip,
@@ -121,22 +121,22 @@ public class IabClient {
     public IabResponse checkAt(String userAgent, InetAddress ipAddress, Date accurateAt) {
         assertCheckAtArguments(userAgent, ipAddress, accurateAt);
 
+        String userAgentLower = IabFile.toLowerCase(userAgent);
+
+        if (matchesAny(userAgentLower, customIncludeUserAgents)) {
+            return IabResponse.identifiedAsBrowser();
+        }
+
+        if (matchesAny(userAgentLower, customExcludeUserAgents)) {
+            return IabResponse.customExcludeCheckFailed();
+        }
+
         if (ipAddress != null && ipRanges.belong(ipAddress)) {
             return IabResponse.ipCheckFailed();
         }
 
         if (userAgent == null) {
             return IabResponse.identifiedAsBrowser();
-        }
-
-        String userAgentLower = IabFile.toLowerCase(userAgent);
-
-        if (matchesAny(userAgentLower, customIncludeUseragents)) {
-            return IabResponse.identifiedAsBrowser();
-        }
-
-        if (matchesAny(userAgentLower, customExcludeUseragents)) {
-            return IabResponse.customExcludeCheckFailed();
         }
 
         if (!includeUserAgents.presentLowerCase(userAgentLower, accurateAt)) {

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClient.java
@@ -139,11 +139,11 @@ public class IabClient {
             return IabResponse.customExcludeCheckFailed();
         }
 
-        if (!includeUserAgents.present(userAgent, accurateAt)) {
+        if (!includeUserAgents.presentLowerCase(userAgentLower, accurateAt)) {
             return IabResponse.includeCheckFailed();
         }
 
-        IabResponse excludeResponse = toIabResponse(excludeUserAgents.check(userAgent), accurateAt);
+        IabResponse excludeResponse = toIabResponse(excludeUserAgents.checkLowerCase(userAgentLower), accurateAt);
         return excludeResponse == null ? IabResponse.identifiedAsBrowser() : excludeResponse;
     }
 

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabResponse.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabResponse.java
@@ -21,9 +21,7 @@ import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.F
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.FAILED_UA_INCLUDE;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.PASSED_ALL;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.NONE;
-import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.PAGE_AND_AD_IMPRESSIONS;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.UNKNOWN;
-import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.ACTIVE_SPIDER_OR_ROBOT;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.BROWSER;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.SPIDER_OR_ROBOT;
 
@@ -79,7 +77,7 @@ public class IabResponse {
     }
 
     static IabResponse customExcludeCheckFailed() {
-        return createForSpiderOrRobot(ACTIVE_SPIDER_OR_ROBOT, FAILED_UA_EXCLUDE, PAGE_AND_AD_IMPRESSIONS);
+        return createForSpiderOrRobot(SPIDER_OR_ROBOT, FAILED_UA_EXCLUDE, UNKNOWN);
     }
 
     private static IabResponse createForSpiderOrRobot(UserAgentCategory category, CheckReason reason,

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabResponse.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabResponse.java
@@ -21,7 +21,9 @@ import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.F
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.FAILED_UA_INCLUDE;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.CheckReason.PASSED_ALL;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.NONE;
+import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.PAGE_AND_AD_IMPRESSIONS;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.PrimaryImpact.UNKNOWN;
+import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.ACTIVE_SPIDER_OR_ROBOT;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.BROWSER;
 import static com.snowplowanalytics.iab.spidersandrobotsclient.lib.UserAgentCategory.SPIDER_OR_ROBOT;
 
@@ -74,6 +76,10 @@ public class IabResponse {
 
     public static IabResponse excludeCheckFailed(UserAgentCategory category, PrimaryImpact primaryImpact) {
         return createForSpiderOrRobot(category, FAILED_UA_EXCLUDE, primaryImpact);
+    }
+
+    static IabResponse customExcludeCheckFailed() {
+        return createForSpiderOrRobot(ACTIVE_SPIDER_OR_ROBOT, FAILED_UA_EXCLUDE, PAGE_AND_AD_IMPRESSIONS);
     }
 
     private static IabResponse createForSpiderOrRobot(UserAgentCategory category, CheckReason reason,

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/lib/internal/ExcludeUserAgents.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/lib/internal/ExcludeUserAgents.java
@@ -44,10 +44,12 @@ public class ExcludeUserAgents {
     }
 
     public ExcludeCheckResult check(String userAgent) {
-        String userAgentLowCase = IabFile.toLowerCase(userAgent);
+        return checkLowerCase(IabFile.toLowerCase(userAgent));
+    }
 
+    public ExcludeCheckResult checkLowerCase(String userAgentLowerCase) {
         for (ExcludeRecord record : records) {
-            if (record.isPresent(userAgentLowCase)) {
+            if (record.isPresent(userAgentLowerCase)) {
                 return ExcludeCheckResult.present(
                         record.getInactiveDateAsDate(), record.getPrimaryImpact()
                 );

--- a/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/lib/internal/IncludeUserAgents.java
+++ b/src/main/java/com/snowplowanalytics/iab/spidersandrobotsclient/lib/internal/IncludeUserAgents.java
@@ -50,10 +50,12 @@ public class IncludeUserAgents {
     }
 
     public boolean present(String userAgent, Date accurateAt) {
-        String userAgentLowCase = IabFile.toLowerCase(userAgent);
+        return presentLowerCase(IabFile.toLowerCase(userAgent), accurateAt);
+    }
 
+    public boolean presentLowerCase(String userAgentLowerCase, Date accurateAt) {
         for (IncludeRecord record : records) {
-            boolean present = record.isPresent(userAgentLowCase);
+            boolean present = record.isPresent(userAgentLowerCase);
             if (present && (record.isActive() || record.isBeforeInactiveDate(accurateAt))) {
                 return true;
             }

--- a/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
+++ b/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
@@ -344,9 +344,9 @@ public class IabClientTest {
         assertResponse(
                 response,
                 true,
-                ACTIVE_SPIDER_OR_ROBOT,
+                SPIDER_OR_ROBOT,
                 FAILED_UA_EXCLUDE,
-                PAGE_AND_AD_IMPRESSIONS
+                UNKNOWN
         );
     }
 

--- a/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
+++ b/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
@@ -151,10 +151,10 @@ public class IabClientTest {
 
     @Test
     public void customIncludeUseragentsTakesPrecedence() throws IOException {
-        List<String> includeUseragents = Arrays.asList("TrustedBot", "InternalMonitor");
-        List<String> excludeUseragents = Collections.emptyList();
+        List<String> includeUserAgents = Arrays.asList("TrustedBot", "InternalMonitor");
+        List<String> excludeUserAgents = Collections.emptyList();
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUserAgents, includeUserAgents);
 
         assertBrowserResponse(client.check("TrustedBot/1.0", localHost));
         assertBrowserResponse(client.check("My InternalMonitor Agent", localHost));
@@ -162,10 +162,10 @@ public class IabClientTest {
 
     @Test
     public void customExcludeUseragentsClassifiesAsBot() throws IOException {
-        List<String> includeUseragents = Collections.emptyList();
-        List<String> excludeUseragents = Arrays.asList("BadBot", "Scraper");
+        List<String> includeUserAgents = Collections.emptyList();
+        List<String> excludeUserAgents = Arrays.asList("BadBot", "Scraper");
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUserAgents, includeUserAgents);
 
         assertCustomExcludeResponse(client.check("BadBot/1.0", localHost));
         assertCustomExcludeResponse(client.check("My Scraper Agent", localHost));
@@ -173,10 +173,10 @@ public class IabClientTest {
 
     @Test
     public void customIncludeOverridesCustomExclude() throws IOException {
-        List<String> includeUseragents = Arrays.asList("TrustedBot");
-        List<String> excludeUseragents = Arrays.asList("Bot");
+        List<String> includeUserAgents = Arrays.asList("TrustedBot");
+        List<String> excludeUserAgents = Arrays.asList("Bot");
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUserAgents, includeUserAgents);
 
         assertBrowserResponse(client.check("TrustedBot/1.0", localHost));
         assertCustomExcludeResponse(client.check("OtherBot/1.0", localHost));
@@ -184,10 +184,10 @@ public class IabClientTest {
 
     @Test
     public void customListsAreCaseInsensitive() throws IOException {
-        List<String> includeUseragents = Arrays.asList("trustedbot");
-        List<String> excludeUseragents = Arrays.asList("badbot");
+        List<String> includeUserAgents = Arrays.asList("trustedbot");
+        List<String> excludeUserAgents = Arrays.asList("badbot");
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUserAgents, includeUserAgents);
 
         assertBrowserResponse(client.check("TRUSTEDBOT/1.0", localHost));
         assertBrowserResponse(client.check("TrustedBot/1.0", localHost));
@@ -197,10 +197,10 @@ public class IabClientTest {
 
     @Test
     public void customListsUseSubstringMatching() throws IOException {
-        List<String> includeUseragents = Arrays.asList("trusted");
-        List<String> excludeUseragents = Arrays.asList("bad");
+        List<String> includeUserAgents = Arrays.asList("trusted");
+        List<String> excludeUserAgents = Arrays.asList("bad");
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, EMPTY, excludeUserAgents, includeUserAgents);
 
         assertBrowserResponse(client.check("MyTrustedAgent/1.0", localHost));
         assertCustomExcludeResponse(client.check("MyBadAgent/1.0", localHost));
@@ -208,10 +208,10 @@ public class IabClientTest {
 
     @Test
     public void customListsTakePrecedenceOverIabFiles() throws IOException {
-        List<String> includeUseragents = Arrays.asList("robot");
-        List<String> excludeUseragents = Collections.emptyList();
+        List<String> includeUserAgents = Arrays.asList("robot");
+        List<String> excludeUserAgents = Collections.emptyList();
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, "Browser|1|0", excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, "Browser|1|0", excludeUserAgents, includeUserAgents);
 
         assertBrowserResponse(client.check("robot", localHost));
     }
@@ -228,10 +228,10 @@ public class IabClientTest {
 
     @Test
     public void customExcludeTakesPrecedenceOverIabIncludeFile() throws IOException {
-        List<String> includeUseragents = Collections.emptyList();
-        List<String> excludeUseragents = Arrays.asList("browser");
+        List<String> includeUserAgents = Collections.emptyList();
+        List<String> excludeUserAgents = Arrays.asList("browser");
 
-        IabClient client = clientWithCustomLists(EMPTY, EMPTY, "browser|1|0", excludeUseragents, includeUseragents);
+        IabClient client = clientWithCustomLists(EMPTY, EMPTY, "browser|1|0", excludeUserAgents, includeUserAgents);
 
         assertCustomExcludeResponse(client.check("browser", localHost));
     }
@@ -246,15 +246,15 @@ public class IabClientTest {
 
     @Test
     public void customIncludeOverridesMatchingExcludePatterns() throws IOException {
-        List<String> includeUseragents = Arrays.asList("AcmeInternalBot");
-        List<String> excludeUseragents = Arrays.asList("bot");
+        List<String> includeUserAgents = Arrays.asList("AcmeInternalBot");
+        List<String> excludeUserAgents = Arrays.asList("bot");
 
         IabClient client = clientWithCustomLists(
                 EMPTY,
                 "bot|1||1|2|0",
                 EMPTY,
-                excludeUseragents,
-                includeUseragents
+                excludeUserAgents,
+                includeUserAgents
         );
 
         assertBrowserResponse(client.check("AcmeInternalBot/2.1", localHost));
@@ -377,14 +377,14 @@ public class IabClientTest {
     private static IabClient clientWithCustomLists(String ipFile,
                                                    String excludeUserAgentFile,
                                                    String includeUserAgentFile,
-                                                   List<String> excludeUseragents,
-                                                   List<String> includeUseragents) throws IOException {
+                                                   List<String> excludeUserAgents,
+                                                   List<String> includeUserAgents) throws IOException {
         return new IabClient(
                 asInputStream(ipFilePrefix(ipFile)),
                 asInputStream(dummyRecordPrefix(excludeUserAgentFile)),
                 asInputStream(dummyRecordPrefix(includeUserAgentFile)),
-                excludeUseragents,
-                includeUseragents);
+                excludeUserAgents,
+                includeUserAgents);
     }
 
 }

--- a/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
+++ b/src/test/java/com/snowplowanalytics/iab/spidersandrobotsclient/IabClientTest.java
@@ -245,6 +245,22 @@ public class IabClientTest {
     }
 
     @Test
+    public void customIncludeOverridesMatchingExcludePatterns() throws IOException {
+        List<String> includeUseragents = Arrays.asList("AcmeInternalBot");
+        List<String> excludeUseragents = Arrays.asList("bot");
+
+        IabClient client = clientWithCustomLists(
+                EMPTY,
+                "bot|1||1|2|0",
+                EMPTY,
+                excludeUseragents,
+                includeUseragents
+        );
+
+        assertBrowserResponse(client.check("AcmeInternalBot/2.1", localHost));
+    }
+
+    @Test
     public void checkFromFiles() throws IOException {
         IabClient client = new IabClient(
                 TestResources.ipExcludeCurrentFile(),


### PR DESCRIPTION
Add new constructor parameters to IabClient:
- excludeUseragents: custom patterns to classify as spiders/robots
- includeUseragents: custom patterns to classify as browsers

Precedence order (highest first):
1. Custom includeUseragents -> browser
2. Custom excludeUseragents -> spider/robot
3. IAB IP file check
4. IAB include file check
5. IAB exclude file check

Matching is case-insensitive substring matching.

ref: https://snplow.atlassian.net/browse/PDP-2425