### PR TITLE
Fix Snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,10 +18,10 @@ jobs:
         distribution: 'temurin'
         cache: 'gradle'
 
+    - name: Install Snyk CLI
+      uses: snyk/actions/setup@master
+
     - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/gradle@master
-      with:
-        command: monitor
-        args: --project-name=iab-spiders-and-robots-java-client
+      run: snyk monitor --project-name=iab-spiders-and-robots-java-client
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
- Use `snyk/actions/setup` to install Snyk CLI natively instead of running via Docker (`snyk/actions/gradle`)
- The Docker-based action bundles JDK 25 which is incompatible with Gradle 8.5, causing `Unsupported class file major version 69` errors
- With the native CLI approach, `setup-java` JDK 21 is used by Gradle as expected

Confirm that SNYK_TOKEN secret is available before merging.